### PR TITLE
use ./index instead of only . when require

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,7 @@
 var stdin = require('get-stdin');
 var argv = require('minimist')(process.argv.slice(2));
 var pkg = require('./package.json');
-var indentString = require('.');
+var indentString = require('./index');
 var input = argv._;
 
 function help() {


### PR DESCRIPTION
I don't know, but this require('.') never work for me on Ubuntu (especially Mint 14)
