### PR TITLE
Add option to indent empty lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,7 @@
 'use strict';
-module.exports = (str, count, options) => {
-	if (options === undefined) {
-		options = {indent: ' ', blank: false};
-	} else if (typeof options === 'object') {
-		options.indent = options.indent === undefined ? ' ' : options.indent;
-		options.blank = options.blank === undefined ? false : options.blank;
-	} else {
-		// Support older versions: use the third parameter as options.indent
-		options = {indent: options, blank: false};
-	}
+module.exports = (str, count, opts) => {
+	// Support older versions: use the third parameter as options.indent
+	const options = typeof opts === 'object' ? Object.assign({indent: ' '}, opts) : {indent: opts || ' '};
 	count = count === undefined ? 1 : count;
 
 	if (typeof str !== 'string') {
@@ -19,16 +12,8 @@ module.exports = (str, count, options) => {
 		throw new TypeError(`Expected \`count\` to be a \`number\`, got \`${typeof count}\``);
 	}
 
-	if (typeof options !== 'object') {
-		throw new TypeError(`Expected \`options\` to be a \`string\` or an \`object\`, got \`${typeof options}\``);
-	}
-
 	if (typeof options.indent !== 'string') {
 		throw new TypeError(`Expected \`options.indent\` to be a \`string\`, got \`${typeof options.indent}\``);
-	}
-
-	if (typeof options.blank !== 'boolean') {
-		throw new TypeError(`Expected \`options.blank\` to be a \`boolean\`, got \`${typeof options.blank}\``);
 	}
 
 	if (count === 0) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
 'use strict';
-module.exports = (str, count, indent) => {
-	indent = indent === undefined ? ' ' : indent;
+module.exports = (str, count, options) => {
+	if (options === undefined) {
+		options = {indent: ' ', blank: false};
+	} else if (typeof options === 'object') {
+		options.indent = options.indent === undefined ? ' ' : options.indent;
+		options.blank = options.blank === undefined ? false : options.blank;
+	} else {
+		// Support older versions: use the third parameter as options.indent
+		options = {indent: options, blank: false};
+	}
 	count = count === undefined ? 1 : count;
 
 	if (typeof str !== 'string') {
@@ -11,13 +19,23 @@ module.exports = (str, count, indent) => {
 		throw new TypeError(`Expected \`count\` to be a \`number\`, got \`${typeof count}\``);
 	}
 
-	if (typeof indent !== 'string') {
-		throw new TypeError(`Expected \`indent\` to be a \`string\`, got \`${typeof indent}\``);
+	if (typeof options !== 'object') {
+		throw new TypeError(`Expected \`options\` to be a \`string\` or an \`object\`, got \`${typeof options}\``);
+	}
+
+	if (typeof options.indent !== 'string') {
+		throw new TypeError(`Expected \`options.indent\` to be a \`string\`, got \`${typeof options.indent}\``);
+	}
+
+	if (typeof options.blank !== 'boolean') {
+		throw new TypeError(`Expected \`options.blank\` to be a \`boolean\`, got \`${typeof options.blank}\``);
 	}
 
 	if (count === 0) {
 		return str;
 	}
 
-	return str.replace(/^(?!\s*$)/mg, indent.repeat(count));
-};
+	const rx = options.blank ? /^/mg : /^(?!\s*$)/mg;
+	return str.replace(rx, options.indent.repeat(count));
+}
+;

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ indentString('Unicorns\nRainbows', 4);
 //=> '    Unicorns'
 //=> '    Rainbows'
 
-indentString('Unicorns\nRainbows', 4, '♥');
+indentString('Unicorns\nRainbows', 4, {indent: '♥'});
 //=> '♥♥♥♥Unicorns'
 //=> '♥♥♥♥Rainbows'
 ```
@@ -27,7 +27,7 @@ indentString('Unicorns\nRainbows', 4, '♥');
 
 ## API
 
-### indentString(input, [count], [indent])
+### indentString(input, [count], [options])
 
 #### input
 
@@ -42,12 +42,23 @@ Default: `1`
 
 How many times you want `indent` repeated.
 
-#### indent
+#### options
+
+Type: `Object`<br>
+
+##### indent
 
 Type: `string`<br>
 Default: `' '`
 
 String to use for the indent.
+
+##### blank
+
+Type: `boolean`<br>
+Default: `false`
+
+Indent blank lines.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -15,11 +15,6 @@ test('throw if indent is not a string', t => {
 	t.throws(() => m('foo', 1, {indent: 1}), 'Expected `options.indent` to be a `string`, got `number`');
 });
 
-test('throw if blank is not a boolean', t => {
-	t.throws(() => m('foo', 1, {blank: 1}), 'Expected `options.blank` to be a `boolean`, got `number`');
-	t.throws(() => m('foo', 1, {blank: 'false'}), 'Expected `options.blank` to be a `boolean`, got `string`');
-});
-
 test('indent each line in a string', t => {
 	t.is(m('foo\nbar'), ' foo\n bar');
 	t.is(m('foo\nbar', 1), ' foo\n bar');
@@ -30,6 +25,7 @@ test('indent each line in a string', t => {
 test('not indent whitespace only lines', t => {
 	t.is(m('foo\nbar\n', 1), ' foo\n bar\n');
 	t.is(m('foo\nbar\n', 1, {blank: false}), ' foo\n bar\n');
+	t.is(m('foo\nbar\n', 1, {blank: null}), ' foo\n bar\n');
 });
 
 test('indent every line if options.blank is true', t => {

--- a/test.js
+++ b/test.js
@@ -11,7 +11,13 @@ test('throw if count is not a number', t => {
 });
 
 test('throw if indent is not a string', t => {
-	t.throws(() => m('foo', 1, 1), 'Expected `indent` to be a `string`, got `number`');
+	t.throws(() => m('foo', 1, 1), 'Expected `options.indent` to be a `string`, got `number`'); // Old syntax
+	t.throws(() => m('foo', 1, {indent: 1}), 'Expected `options.indent` to be a `string`, got `number`');
+});
+
+test('throw if blank is not a boolean', t => {
+	t.throws(() => m('foo', 1, {blank: 1}), 'Expected `options.blank` to be a `boolean`, got `number`');
+	t.throws(() => m('foo', 1, {blank: 'false'}), 'Expected `options.blank` to be a `boolean`, got `string`');
 });
 
 test('indent each line in a string', t => {
@@ -23,10 +29,23 @@ test('indent each line in a string', t => {
 
 test('not indent whitespace only lines', t => {
 	t.is(m('foo\nbar\n', 1), ' foo\n bar\n');
+	t.is(m('foo\nbar\n', 1, {blank: false}), ' foo\n bar\n');
+});
+
+test('indent every line if options.blank is true', t => {
+	t.is(m('foo\n\nbar\n	', 1, {blank: true}), ' foo\n \n bar\n 	');
 });
 
 test('indent with leading whitespace', t => {
 	t.is(m(' foo\n bar\n', 1), '  foo\n  bar\n');
+});
+
+test('indent with custom string', t => {
+	t.is(m('foo\nbar\n', 1, {indent: '♥'}), '♥foo\n♥bar\n');
+});
+
+test('indent with custom string and old syntax', t => {
+	t.is(m('foo\nbar\n', 1, '#'), '#foo\n#bar\n');
 });
 
 test('not indent when count is 0', t => {


### PR DESCRIPTION
As said in issue #12, the third parameter is now a map of options.

The options are `indent`, the string to indent with, and `blank`, a boolean to choose if the blank lines should be indented or not (default to `false`, as it was before).

I have added a few tests, including one using the `indent` parameter, which was not tested before.

Everything is still compatible with previous versions: if the third parameter is not undefined and not an object, il will be used as `options.indent`.