### PR TITLE
Ensure `count` is not a negative number

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,12 @@ module.exports = (string, count = 1, options) => {
 		);
 	}
 
+	if (count < 0) {
+		throw new RangeError(
+			`Expected \`count\` to be at least 0, got \`${count}\``
+		);
+	}
+
 	if (typeof options.indent !== 'string') {
 		throw new TypeError(
 			`Expected \`options.indent\` to be a \`string\`, got \`${typeof options.indent}\``

--- a/test.js
+++ b/test.js
@@ -17,6 +17,12 @@ test('throw if count is not a number', t => {
 	}, 'Expected `count` to be a `number`, got `string`');
 });
 
+test('throw if count is a negative', t => {
+	t.throws(() => {
+		indentString('foo', -1);
+	}, 'Expected `count` to be at least 0, got `-1`');
+});
+
 test('throw if indent is not a string', t => {
 	t.throws(() => {
 		indentString('foo', 1, {indent: 1});


### PR DESCRIPTION
If we don't catch `count < 0`, `options.indent.repeat(count)` will throw a `RangeError`, but I think we should catch this case.